### PR TITLE
Add pylint config for pack ci repo itself

### DIFF
--- a/python/.pylintrc-pack-ci
+++ b/python/.pylintrc-pack-ci
@@ -1,0 +1,33 @@
+[MESSAGES CONTROL]
+# C0111 Missing docstring
+# I0011 Warning locally suppressed using disable-msg
+# I0012 Warning locally suppressed using disable-msg
+# W0704 Except doesn't do anything Used when an except clause does nothing but "pass" and there is no "else" clause
+# W0142 Used * or * magic* Used when a function or method is called using *args or **kwargs to dispatch arguments.
+# W0212 Access to a protected member %s of a client class
+# W0232 Class has no __init__ method Used when a class has no __init__ method, neither its parent classes.
+# W0511 Used when a warning note as FIXME or XXX is detected.
+# W0613 Unused argument %r Used when a function or method argument is not used.
+# W0702 No exception's type specified Used when an except clause doesn't specify exceptions type to catch.
+# R0201 Method could be a function
+# W0614 Unused import XYZ from wildcard import
+# W0621 Redefining name %r from outer scope (line %s) Used when a variable’s name hide a name defined in the outer scope.
+# R0914 Too many local variables
+# R0912 Too many branches
+# R0915 Too many statements
+# R0913 Too many arguments
+# R0904 Too many public methods
+# E0211: Method has no argument
+# E1128: Assigning to function call which only returns None Used when an assignment is done on a function call but the inferred function returns nothing but None.
+# E1129: Context manager ‘%s’ doesn’t implement __enter__ and __exit__. Used when an instance in a with statement doesn’t implement the context manager protocol(__enter__/__exit__).
+disable=C0103,C0111,I0011,I0012,W0704,W0142,W0212,W0232,W0511,W0613,W0702,R0201,W0614,W0621,R0914,R0912,R0915,R0913,R0904,R0801,not-context-manager,assignment-from-none
+
+[TYPECHECK]
+# Note: This modules are manipulated during the runtime so we can't detect all the properties during
+# static analysis
+ignored-modules=distutils,eventlet.green.subprocess,six,six.moves,st2common
+
+[FORMAT]
+max-line-length=100
+max-module-lines=1000
+indent-string='    '


### PR DESCRIPTION
Modified from `python/.pylintrc`, this turns off a few more warnings.

This is used for the [StackStorm-Exchange/ci](https://github.com/StackStorm-Exchange/ci) repository itself, to ensure that Python files in that repository are linted, but also so that they work in both Python 2.7 and Python 3.6, since packs like [stackstorm-fortinet](https://github.com/StackStorm-Exchange/stackstorm-fortinet) only support Python 3.6, including being deployed from a Python 3.6 environment.